### PR TITLE
Disable f-strings in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
         name: pylint (library code)
         types: [python]
         exclude: "^(docs/|examples/|tests/|setup.py$)"
+        args: ["--disable=consider-using-f-string"]
 -   repo: local
     hooks:
     -   id: pylint_examples


### PR DESCRIPTION
Should fix remaining CI error

See https://github.com/adafruit/Adafruit_CircuitPython_24LC32/pull/20 for similar PR