### PR TITLE
Measurement quality

### DIFF
--- a/adafruit_vl53l4cd.py
+++ b/adafruit_vl53l4cd.py
@@ -226,6 +226,13 @@ class VL53L4CD:
         return status
 
     @property
+    def sigma(self):
+        """Sigma estimator for the noise in the reported target distance in units of centimeters."""
+        sigma = self._read_register(_VL53L4CD_RESULT_SIGMA, 2)
+        sigma = struct.unpack(">H", sigma)[0]
+        return sigma / 40
+
+    @property
     def timing_budget(self):
         """Ranging duration in milliseconds. Valid range is 10ms to 200ms."""
         osc_freq = struct.unpack(">H", self._read_register(0x0006, 2))[0]

--- a/adafruit_vl53l4cd.py
+++ b/adafruit_vl53l4cd.py
@@ -200,6 +200,32 @@ class VL53L4CD:
         return dist / 10
 
     @property
+    def range_status(self):
+        """Measurement validity. Returns a number between 0 to 255 where:
+        0 - None - Returned distance is valid
+        1 - Warning - Sigma is above the defined threshold
+        2 - Warning - Signal is below the defined threshold
+        3 - Error - Measured distance is below detection threshold
+        4 - Error - Phase out of valid limit
+        5 - Error - Hardware fail
+        6 - Warning - Phase valid but no wrap around check performed
+        7 - Error - Wrapped target, phase does not match
+        8 - Error - Processing fail
+        9 - Error - Crosstalk signal fail
+        10 - Error - Interrupt error
+        11 - Error - Merged target
+        12 - Error - Signal is too low
+        255 - Error - Other error (for example, boot error)
+        """
+        status_rtn = [255, 255, 255, 5, 2, 4, 1, 7, 3, 0, 255, 255, 9, 13, 255, 255, 255, 255, 10, 6, 255, 255, 11, 12]
+        status = self._read_register(_VL53L4CD_RESULT_RANGE_STATUS, 1)
+        status = struct.unpack(">B", status)[0]
+        status = status & 0x1F
+        if status < 24:
+            status = status_rtn[status]
+        return status
+
+    @property
     def timing_budget(self):
         """Ranging duration in milliseconds. Valid range is 10ms to 200ms."""
         osc_freq = struct.unpack(">H", self._read_register(0x0006, 2))[0]


### PR DESCRIPTION
Added functions to check measurement quality. This helps determine if the value read is actually usable.

Tested with example vl53l4cd_simpletest.py replacing line:
`print("Distance: {} cm".format(vl53.distance))`
by:
`print("Status: {:3d} Distance: {:6.2f}cm, Estimated noise: {:6.2f}cm".format(vl53.range_status, vl53.distance, vl53.sigma))`